### PR TITLE
Add rewrite rules for Vercel routing

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/" }
+  ]
+}


### PR DESCRIPTION
rewrite rules 

React apps with client-side routing (like React Router DOM) need a special setting in Vercel to rewrite all routes to your index.html, so the router can take over.